### PR TITLE
Solucionado error que impedía mostrar participantes de Gimnasia

### DIFF
--- a/front-end/static-files/js/ms-gimnasia.js
+++ b/front-end/static-files/js/ms-gimnasia.js
@@ -430,8 +430,8 @@ Gimnasia.GimnasiaTablaPersonas.pie = `        </tbody>
              `;
 
 
-Gimnasia.sustituyeTags = function (Gimnasia, persona) {   //hecho el TDD
-    return Gimnasia
+Gimnasia.sustituyeTags = function (gimnasia, persona) {   //hecho el TDD
+    return gimnasia
     .replace(new RegExp(Gimnasia.GimnasiaTags.ID, 'g'), persona.ref['@ref'].id)
     .replace(new RegExp(Gimnasia.GimnasiaTags.NOMBRE, 'g'), persona.data.nombre)
     .replace(new RegExp(Gimnasia.GimnasiaTags.PAIS, 'g'), persona.data.pais)


### PR DESCRIPTION
El problema era que en la función Gimnasia.sustituyeTags se pasaba un parámetro llamado Gimnasia en vez de gimnasia.

Eso hacía que NO tomara los datos predefinidos en el objeto Gimnasia.